### PR TITLE
fix(autorun): Switch from Meteor.autorun to Tracker.autorun

### DIFF
--- a/keycloak-loader/keycloak-loader.js
+++ b/keycloak-loader/keycloak-loader.js
@@ -1,7 +1,9 @@
+import { Tracker } from 'meteor/tracker';
+
 const loader = new Promise((resolve, reject) => {
 
 
-    Meteor.autorun(function(c) {
+    Tracker.autorun(function(c) {
         if (Accounts.loginServicesConfigured()) {
             c.stop();
             start();

--- a/keycloak-loader/package.js
+++ b/keycloak-loader/package.js
@@ -1,6 +1,6 @@
 Package.describe({
     name: 'mxab:keycloak-loader',
-    version: '0.0.1',
+    version: '0.0.2',
     // Brief, one-line summary of the package.
     summary: 'Loads the keycloak.js from the Keycloak Server and creates an instance',
     // URL to the Git repository containing the source code for this package.


### PR DESCRIPTION
Hello!

This switches Meteor.autorun to Tracker.autorun inside keycloak-loader, as the former is now deprecated.

Thanks!